### PR TITLE
made nav menu a bit more responsive with extra media query

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -130,7 +130,7 @@ margin-left: 25%;
   text-decoration: none;
 }
 
-@media (max-width:500px){
+@media screen (max-width:500px){
   li{
     display: flex;
     flex-direction: column;
@@ -138,7 +138,7 @@ margin-left: 25%;
   }
 }
 
-@media (min-width:500px) {
+@media screen (min-width:500px) {
 
   .project section p{
     font-size: 1.5rem;
@@ -152,6 +152,17 @@ margin-left: 25%;
     font-size: 1.5rem;
   }
 
+  .icon img{
+  width:4rem;
+  height:4rem;
+  }
+
+  .copy{
+    border-bottom: thin solid black;
+  }
+}
+
+@media screen and (min-width: 700px) {
   article{
     margin-left: 25%;
   }
@@ -174,14 +185,5 @@ margin-left: 25%;
     font-size: 1.25rem;
     align-items: flex-end;
     height: 5rem;
-  }
-
-  .icon img{
-  width:4rem;
-  height:4rem;
-  }
-
-  .copy{
-    border-bottom: thin solid black;
   }
 }


### PR DESCRIPTION
I added an additional media query with a min-width of 700px, and made the top nav menu move to the left of the screen there rather than at 500px.  This is because the link text would flow outside of the nav bar in the when the window is in the 500px to 700px range.  I also added 'screen and' to each of the media queries.